### PR TITLE
fix: Add ExportNamedDeclaration to node identifier.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (babel) {
 
   return {
     visitor: {
-      ImportDeclaration: function (path) {
+      'ImportDeclaration|ExportNamedDeclaration': function (path) {
         path.traverse(sourceVisitor)
       }
     }


### PR DESCRIPTION
Adding ExportNamedDeclaration covers the case:
`export { default as Foo } from './Foo.jsx';`